### PR TITLE
Add python, plus tests with inspec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.python?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=184&branchName=master)
+
+# python
+
+Python is a programming language that lets you work quickly and integrate systems more effectively.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "python"

--- a/controls/python_works.rb
+++ b/controls/python_works.rb
@@ -1,0 +1,41 @@
+title 'Tests to confirm python works as expected'
+
+plan_name = input('plan_name', value: 'python')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-python' do
+  impact 1.0
+  title 'Ensure python works'
+  desc '
+  For python we check that the version is correctly returned e.g.
+
+    $ python --version
+    Python 3.8.3
+
+  As is often customary, we also say hello to the world with python:
+
+    $ python -c "print(\'hello world\')"
+    hello world
+  '
+  python_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe python_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  python_pkg_ident = python_pkg_ident.stdout.strip
+
+  describe command("#{python_pkg_ident}/bin/python --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /Python\s+#{python_pkg_ident.split('/')[5]}/ }
+    its('stderr') { should be_empty }
+  end
+
+  describe command("#{python_pkg_ident}/bin/python -c \"print('hello world')\"") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /hello world/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: python
+title: Habitat Core Plan for python
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan for python
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,23 @@
+$pkg_name="python"
+$pkg_version="3.7.3"
+$pkg_origin="core"
+$pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+$pkg_license=@('Python-2.0')
+$pkg_description="Python is a programming language that lets you work quickly and integrate systems more effectively."
+$pkg_upstream_url="https://www.python.org"
+$pkg_build_deps=@("core/nuget")
+$pkg_bin_dirs=@("bin", "bin/Scripts")
+
+function Invoke-Build {
+    nuget install python -version $pkg_version -ExcludeVersion -OutputDirectory "$HAB_CACHE_SRC_PATH/$pkg_dirname"
+}
+
+function Invoke-Install {
+    Remove-Item "$pkg_prefix/bin/Scripts"
+    Copy-Item "$HAB_CACHE_SRC_PATH/$pkg_dirname/python/tools/*" "$pkg_prefix/bin" -Recurse
+}
+
+function Invoke-Check {
+    & "$HAB_CACHE_SRC_PATH/$pkg_dirname/python/tools/python" -m pip --version
+    if($LASTEXITCODE -ne 0) { Write-Error "Invoke check failed with error code $LASTEXITCODE" }
+}

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,86 @@
+pkg_name=python
+pkg_distname=Python
+pkg_version=3.7.0
+pkg_origin=core
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Python-2.0')
+pkg_description="Python is a programming language that lets you work quickly \
+  and integrate systems more effectively."
+pkg_upstream_url="https://www.python.org"
+pkg_dirname="${pkg_distname}-${pkg_version}"
+pkg_source="https://www.python.org/ftp/python/${pkg_version}/${pkg_dirname}.tgz"
+pkg_shasum="85bb9feb6863e04fb1700b018d9d42d1caac178559ffa453d7e6a436e259fd0d"
+
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+pkg_interpreters=(bin/python bin/python3 bin/python3.7)
+
+pkg_deps=(
+  core/bzip2
+  core/expat
+  core/gcc-libs
+  core/gdbm
+  core/glibc
+  core/libffi
+  core/ncurses
+  core/openssl
+  core/readline
+  core/sqlite
+  core/zlib
+)
+
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/gcc
+  core/linux-headers
+  core/make
+  core/util-linux
+)
+
+do_prepare() {
+  sed -i.bak 's/#zlib/zlib/' Modules/Setup.dist
+  sed -i -re "/(SSL=|_ssl|-DUSE_SSL|-lssl).*/ s|^#||" Modules/Setup.dist
+}
+
+do_build() {
+  export LDFLAGS="$LDFLAGS -lgcc_s"
+
+  # TODO: We should build with `--enable-optimizations`
+  ./configure --prefix="$pkg_prefix" \
+              --enable-loadable-sqlite-extensions \
+              --enable-shared \
+              --with-threads \
+              --with-system-expat \
+              --with-system-ffi \
+              --with-ensurepip
+
+  make
+}
+
+do_check() {
+  make test
+}
+
+do_install() {
+  do_default_install
+
+  # link pythonx.x to python for pkg_interpreters
+  local minor=${pkg_version%.*}
+  local major=${minor%.*}
+  ln -rs "$pkg_prefix/bin/pip$minor" "$pkg_prefix/bin/pip"
+  ln -rs "$pkg_prefix/bin/pydoc$minor" "$pkg_prefix/bin/pydoc"
+  ln -rs "$pkg_prefix/bin/python$minor" "$pkg_prefix/bin/python"
+  ln -rs "$pkg_prefix/bin/python$minor-config" "$pkg_prefix/bin/python-config"
+
+  # Remove idle as we are not building with Tk/x11 support so it is useless
+  rm -vf "$pkg_prefix/bin/idle$major"
+  rm -vf "$pkg_prefix/bin/idle$minor"
+
+  platlib=$(python -c "import sysconfig;print(sysconfig.get_path('platlib'))")
+  cat <<EOF > "$platlib/_manylinux.py"
+# Disable binary manylinux1(CentOS 5) wheel support
+manylinux1_compatible = False
+EOF
+}


### PR DESCRIPTION
Migration from core plans:

```
Profile: Habitat Core Plan for python (python)
Version: 0.1.0
Target:  docker://f0e619afe9202c488f29247662c325cf52c39d37675797d8d7e9ddc683e2bfef

  ✔  core-plans-python: Ensure python works
     ✔  Command: `hab pkg path habskp/python` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/python` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python --version` stdout is expected to match /Python\s+3.7.0/
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python --version` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python -c "print('hello world')"` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python -c "print('hello world')"` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python -c "print('hello world')"` stdout is expected to match /hello world/
     ✔  Command: `/hab/pkgs/habskp/python/3.7.0/20200610131538/bin/python -c "print('hello world')"` stderr is expected to be empty
```


﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
