### PR TITLE
Add LZMA support

### DIFF
--- a/plan.sh
+++ b/plan.sh
@@ -27,6 +27,7 @@ pkg_deps=(
   core/openssl
   core/readline
   core/sqlite
+  core/xz
   core/zlib
 )
 

--- a/x86_64-linux-kernel2/plan.sh
+++ b/x86_64-linux-kernel2/plan.sh
@@ -27,6 +27,7 @@ pkg_deps=(
   core/openssl
   core/readline
   core/sqlite/3.35.1
+  core/xz
   core/zlib
 )
 


### PR DESCRIPTION
This activates the `lzma` [module](https://docs.python.org/3/library/lzma.html) of python, for python programs that need it (in my case, it was [deluge](https://www.deluge-torrent.org).